### PR TITLE
Modified database initialisation script

### DIFF
--- a/account/infrastructure/resources/database/01_create_account_tables.sql
+++ b/account/infrastructure/resources/database/01_create_account_tables.sql
@@ -1,4 +1,4 @@
-CREATE SCHEMA account;
+CREATE SCHEMA IF NOT EXISTS account;
 
 USE account;
 
@@ -11,18 +11,20 @@ CREATE TABLE events (
     event_name         VARCHAR(50)   NOT NULL,
     event_version      VARCHAR(10)   NOT NULL,
     event_payload      JSON          NOT NULL,
-    metadata           JSON          NOT NULL
+    metadata           JSON          NOT NULL,
+    created_at         DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE UNIQUE INDEX ix01_events ON events (aggregate_name, aggregate_id, aggregate_sequence);
 
 -- identity aggregate table
 CREATE TABLE identities (
-    user_id   VARBINARY(16) NOT NULL,
-    user_role VARCHAR(10)   NOT NULL,
-    refresh_token VARCHAR(256) NULL,
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    modified_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    user_id       VARBINARY(16) NOT NULL,
+    user_role     VARCHAR(10)   NOT NULL,
+    refresh_token VARCHAR(256)  NULL,
+    created_at    DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at   DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE UNIQUE INDEX ix01_identities ON identities (user_id);


### PR DESCRIPTION
Tried to implement `sqlx::migrate!`, but it looks weird to do this in api module even though the database schema is managed by infrastructure moduel. Furthermore, `sqlx::migrate!` cannot detect schema changes when Rust code doesn't change which is technically known limit. So I think I'll do database migration pipeline later with atlas.